### PR TITLE
Add compile-time compatability for mr1

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -28,6 +28,7 @@ object build extends Build {
   lazy val projectSettings: Seq[Settings] = Seq(
     name := "poacher"
   , version in ThisBuild := s"""1.0.0-${Option(System.getenv("HADOOP_VERSION")).getOrElse("cdh5")}"""
+  , unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${Option(System.getenv("HADOOP_VERSION")).getOrElse("cdh5")}"
   , organization := "com.ambiata"
   , scalaVersion := "2.11.2"
   , crossScalaVersions := Seq("2.11.2")

--- a/src/main/scala-cdh4/com/ambiata/poacher/Compatibility.scala
+++ b/src/main/scala-cdh4/com/ambiata/poacher/Compatibility.scala
@@ -1,0 +1,11 @@
+package com.ambiata.poacher
+
+import com.ambiata.poacher.mr.DistCache
+
+import org.apache.hadoop.conf.Configuration
+
+object Compatibility {
+  def findCacheFile(conf: Configuration, nskey: DistCache.NamespacedKey): String =
+    com.nicta.scoobi.impl.util.Compatibility.cache.getLocalCacheFiles(conf).toList.find(_.getName == nskey.combined)
+      .getOrElse(sys.error(s"Could not find $nskey to pop from local path.")).toString
+}

--- a/src/main/scala-cdh5/com/ambiata/poacher/Compatibility.scala
+++ b/src/main/scala-cdh5/com/ambiata/poacher/Compatibility.scala
@@ -1,0 +1,10 @@
+package com.ambiata.poacher
+
+import com.ambiata.poacher.mr.DistCache
+
+import org.apache.hadoop.conf.Configuration
+
+object Compatibility {
+  def findCacheFile(conf: Configuration, nskey: DistCache.NamespacedKey): String =
+    nskey.combined
+}


### PR DESCRIPTION
This is just a first pass to get something that works, but as discussed we should rename cdh4/cdh4 to mr1/yarn. I'll do that after this PR.