### PR TITLE
Fail in local mode mv when parent doesn't exist

### DIFF
--- a/project/depend.scala
+++ b/project/depend.scala
@@ -21,7 +21,7 @@ object depend {
                   Seq("com.ambiata"          %% "mundane-testing" % mundaneVersion % "test")
 
   val shapeless = Seq("com.chuusai"          %% "shapeless"       % "2.0.0")
-  val disorder =  Seq("com.ambiata"          %% "disorder"        % "0.0.1-20150102073535-5c2d9d6" % "test")
+  val disorder =  Seq("com.ambiata"          %% "disorder"        % "0.0.1-20150218051243-69499b9" % "test")
 
   def scoobi(version: String) = {
     val jars =

--- a/src/test/scala/com/ambiata/poacher/hdfs/Arbitraries.scala
+++ b/src/test/scala/com/ambiata/poacher/hdfs/Arbitraries.scala
@@ -5,12 +5,15 @@ import Arbitrary._
 import scalaz._, Scalaz._, effect.IO
 import com.ambiata.mundane.control._
 import com.ambiata.mundane.io._
+import com.ambiata.disorder.GenPlus
 
 object Arbitraries {
   implicit def HdfsTemporaryArbitrary: Arbitrary[HdfsTemporary] = Arbitrary(for {
-    i <- Gen.choose(1, 5)
-    a <- Gen.listOfN(i, Gen.identifier)
-    z = a.mkString("/")
+    z <- arbitrary[SubPath]
     f <- Gen.oneOf("", "/")
-  } yield HdfsTemporary(s"temporary-${java.util.UUID.randomUUID().toString}/" + z + f))
+  } yield HdfsTemporary(s"temporary-${java.util.UUID.randomUUID().toString}/" + z.path + f))
+
+  case class SubPath(path: String)
+  implicit def SubPathArbitrary: Arbitrary[SubPath] =
+    Arbitrary(GenPlus.listOfSized(1, 5, Gen.identifier).map(_.mkString("/")).map(SubPath.apply))
 }


### PR DESCRIPTION
This makes local mode more consistent with distributed mode when doing a move.

It was hiding bugs in tests where the destination parent dir wasn't being explicitly created.