### PR TITLE
committer mapping can't be None

### DIFF
--- a/src/main/scala/com/ambiata/poacher/mr/Committer.scala
+++ b/src/main/scala/com/ambiata/poacher/mr/Committer.scala
@@ -19,11 +19,11 @@ object Committer {
    * If the destination dir or any of the children in context.output is a file, an error
    * will be returned.
    */
-  def commit(context: MrContext, mapping: Option[Component] => HdfsPath, cleanup: Boolean): Hdfs[Unit] = for {
+  def commit(context: MrContext, mapping: Component => HdfsPath, cleanup: Boolean): Hdfs[Unit] = for {
     g <- context.output.globPaths("*")
     h =  HdfsPath.filterHidden(g)
     _ <- h.traverse(p => for {
-      n <- Hdfs.ok(mapping(p.basename))
+      n <- Hdfs.fromOption(p.basename, s"Output is a top level dir, can't commit").map(mapping)
       e <- n.exists
       l <- if (e) n.globPaths("*")
            else   nil.pure[Hdfs]

--- a/src/test/scala/com/ambiata/poacher/mr/CommitterSpec.scala
+++ b/src/test/scala/com/ambiata/poacher/mr/CommitterSpec.scala
@@ -23,7 +23,7 @@ Committer
          c = MrContext(ContextId.randomContextId)
          o = c.output
          _ <- (o /- "path1/f1").write("test1") >> (o /- "path2/f2").write("test2")
-         _ <- Committer.commit(c, oc => if (oc == Component("path1").some) p /- "p1" else p /- "p2", true)
+         _ <- Committer.commit(c, oc => if (oc == Component("path1")) p /- "p1" else p /- "p2", true)
          a <- (p /- "p1/f1").readOrFail
          b <- (p /- "p2/f2").readOrFail
        } yield a -> b ==== "test1" -> "test2")
@@ -89,7 +89,7 @@ Committer
          c = MrContext(ContextId.randomContextId)
          o = c.output
          _ <- (o /- "path1/s1/f1").write("test1") >> (o /- "path2/s2/s3/f2").write("test2")
-         _ <- Committer.commit(c, oc => if (oc == Component("path1").some) p /- "p1" else p /- "p2", true)
+         _ <- Committer.commit(c, oc => if (oc == Component("path1")) p /- "p1" else p /- "p2", true)
          a <- (p /- "p1/s1/f1").readOrFail
          b <- (p /- "p2/s2/s3/f2").readOrFail
        } yield a -> b ==== "test1" -> "test2")


### PR DESCRIPTION
@markhibberd @nhibberd Noticed this yesterday, the committer uses `MrContext.output.globPaths(*)` to get a list of sub dirs which it passes to the `mapping` function. Im not sure why the `mapping` function takes an `Option[Component]` because i can't see a case when it will be `None`, as this will mean the output dir is at the top level, which it can't looking at [MrContext](https://github.com/ambiata/poacher/blob/master/src/main/scala/com/ambiata/poacher/mr/Context.scala#L29).