### PR TITLE
mkdirs parent of destination when moving

### DIFF
--- a/src/main/scala/com/ambiata/poacher/hdfs/HdfsDirectory.scala
+++ b/src/main/scala/com/ambiata/poacher/hdfs/HdfsDirectory.scala
@@ -68,6 +68,7 @@ class HdfsDirectory private (val path: Path) extends AnyVal {
       case Some(_) =>
         doesExist(s"Source directory does not exists. HdfsDirectory($path)",
           destination.doesNotExist(s"A file/directory exists in the target location $destination. Can not move source directory HdfsDirectory($path).", for {
+            _ <- destination.dirname.mkdirs // this will only happen as part of the rename below in local mode
             s <- Hdfs.filesystem
             d <- Hdfs.safe({
               // Evil. Unfortunate moving dirs to dirs in HDFS is (intentionally) broken in local mode

--- a/src/main/scala/com/ambiata/poacher/hdfs/HdfsFile.scala
+++ b/src/main/scala/com/ambiata/poacher/hdfs/HdfsFile.scala
@@ -172,6 +172,7 @@ class HdfsFile private (val path: Path) extends AnyVal {
     doesExist(s"Source file does not exist. HdfsFile($path)",
       destination.doesNotExist(s"A file/directory exists in target location $destination. Can not move source file HdfsFile($path)",
         for {
+          _ <- destination.dirname.mkdirs // this will only happen as part of the rename below in local mode
           m <- withFileSystem(_.rename(toHPath, destination.toHPath))
           _ <- Hdfs.unless(m)(Hdfs.fail(s"Failed to move HdfsFile($path) to HdfsFile($destination)"))
         } yield HdfsFile.unsafe(destination.path.path)))


### PR DESCRIPTION
@markhibberd @nhibberd Hit another discrepancy between local and dfs mode when moving files/dirs. If the destination parent dir doesn't exist, it will create it in local mode, but will fail in dfs mode.
